### PR TITLE
Add streaming job for NEM dispatch bronze table

### DIFF
--- a/spark_jobs/bronze_stream.py
+++ b/spark_jobs/bronze_stream.py
@@ -1,0 +1,83 @@
+from pyspark.sql import SparkSession
+from pyspark.sql.types import StructType, StructField, TimestampType, StringType, DoubleType
+from pyspark.sql.functions import from_csv, col, to_date, current_timestamp
+import argparse
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Stream nem_dispatch data from Kafka to Iceberg")
+    parser.add_argument("--kafka-bootstrap-servers", required=True,
+                        help="Kafka bootstrap servers, e.g. localhost:9092")
+    parser.add_argument("--checkpoint-path", required=True,
+                        help="S3/MinIO path for streaming checkpoints")
+    parser.add_argument("--kafka-topic", default="nem_dispatch",
+                        help="Kafka topic to subscribe")
+    parser.add_argument("--table-name", default="nem.bronze_dispatch",
+                        help="Iceberg table name")
+    parser.add_argument("--warehouse", default="s3a://warehouse",
+                        help="Iceberg warehouse location")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    spark = (
+        SparkSession.builder.appName("bronze_dispatch_stream")
+        .config("spark.sql.catalog.nem", "org.apache.iceberg.spark.SparkCatalog")
+        .config("spark.sql.catalog.nem.type", "hadoop")
+        .config("spark.sql.catalog.nem.warehouse", args.warehouse)
+        .getOrCreate()
+    )
+
+    # Ensure Iceberg table exists
+    spark.sql(
+        f"""
+        CREATE TABLE IF NOT EXISTS {args.table_name} (
+            trading_interval TIMESTAMP,
+            region STRING,
+            demand DOUBLE,
+            trading_date DATE,
+            ingested_at TIMESTAMP
+        )
+        USING iceberg
+        PARTITIONED BY (trading_date)
+        """
+    )
+
+    schema = StructType([
+        StructField("trading_interval", TimestampType()),
+        StructField("region", StringType()),
+        StructField("demand", DoubleType()),
+    ])
+
+    raw_df = (
+        spark.readStream.format("kafka")
+        .option("kafka.bootstrap.servers", args.kafka_bootstrap_servers)
+        .option("subscribe", args.kafka_topic)
+        .option("startingOffsets", "latest")
+        .load()
+        .selectExpr("CAST(value AS STRING) AS csv")
+    )
+
+    parsed_df = raw_df.select(from_csv(col("csv"), schema).alias("data")).select("data.*")
+
+    output_df = (
+        parsed_df
+        .withColumn("trading_date", to_date(col("trading_interval")))
+        .withColumn("ingested_at", current_timestamp())
+    )
+
+    query = (
+        output_df.writeStream
+        .format("iceberg")
+        .outputMode("append")
+        .option("checkpointLocation", args.checkpoint_path)
+        .toTable(args.table_name)
+    )
+
+    query.awaitTermination()
+
+
+if __name__ == "__main__":
+    main()

--- a/submit_bronze.sh
+++ b/submit_bronze.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JOB_FILE="spark_jobs/bronze_stream.py"
+JAR_PACKAGES="org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:1.4.2,org.apache.spark:spark-sql-kafka-0-10_2.12:3.3.2"
+
+usage() {
+  echo "Usage: $0 [local|emr]" >&2
+  exit 1
+}
+
+MODE=${1:-local}
+
+if [[ "$MODE" == "local" ]]; then
+  spark-submit \
+    --packages "$JAR_PACKAGES" \
+    "$JOB_FILE" \
+    --kafka-bootstrap-servers "${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}" \
+    --checkpoint-path "${CHECKPOINT_PATH:-s3a://lakehouse/checkpoints/bronze_dispatch}"
+elif [[ "$MODE" == "emr" ]]; then
+  [[ -z "${APPLICATION_ID:-}" || -z "${EMR_ROLE_ARN:-}" ]] && usage
+  JOB_DRIVER=$(cat <<JSON
+{"sparkSubmit":{
+  "entryPoint":"$JOB_FILE",
+  "entryPointArguments":[
+    "--kafka-bootstrap-servers","${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}",
+    "--checkpoint-path","${CHECKPOINT_PATH:-s3a://lakehouse/checkpoints/bronze_dispatch}"
+  ],
+  "sparkSubmitParameters":"--packages $JAR_PACKAGES"
+}}
+JSON
+)
+
+  aws emr-serverless start-job-run \
+    --application-id "$APPLICATION_ID" \
+    --execution-role-arn "$EMR_ROLE_ARN" \
+    --job-driver "$JOB_DRIVER"
+else
+  usage
+fi


### PR DESCRIPTION
## Summary
- add Spark Structured Streaming job that consumes the `nem_dispatch` Kafka topic and writes parsed CSV rows to an Iceberg table partitioned by `trading_date`
- include script to submit the job locally or via EMR Serverless with checkpointing to S3/MinIO

## Testing
- `python -m py_compile spark_jobs/bronze_stream.py`
- `bash -n submit_bronze.sh`


