### PR TITLE
Add Prometheus exporters, Grafana dashboards, and Slack alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # KangarooCurrents-Real-Time-Lakehouse-for-Australia-s-Electricity-Grid
+
+This repository includes monitoring assets for the real-time electricity grid lakehouse.
+
+## Exporters
+Configuration files for Prometheus exporters are located in `monitoring/exporters` and cover:
+- Spark
+- Kafka
+- Airflow
+- Flink
+
+## Grafana Dashboards
+JSON exports for Grafana are stored in `docs/grafana` and include dashboards for:
+- Generation mix
+- Consumer lag
+- Forecast error
+
+## Alerting
+Prometheus Alertmanager configuration and rules live in `monitoring/alerts`. Alerts are sent to Slack for:
+- High coal percentage of total generation
+- Pipeline failures
+
+Set the `SLACK_WEBHOOK_URL` environment variable and update channel names as needed before deploying the alerting stack.

--- a/docs/grafana/consumer-lag.json
+++ b/docs/grafana/consumer-lag.json
@@ -1,0 +1,21 @@
+{
+  "title": "Consumer Lag",
+  "schemaVersion": 16,
+  "version": 0,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Kafka Consumer Lag",
+      "targets": [
+        {
+          "expr": "sum(kafka_consumer_lag)",
+          "legendFormat": "lag"
+        }
+      ],
+      "yaxes": [
+        {"format": "short"},
+        {"format": "short"}
+      ]
+    }
+  ]
+}

--- a/docs/grafana/forecast-error.json
+++ b/docs/grafana/forecast-error.json
@@ -1,0 +1,21 @@
+{
+  "title": "Forecast Error",
+  "schemaVersion": 16,
+  "version": 0,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Forecast Error %",
+      "targets": [
+        {
+          "expr": "avg(electricity_forecast_error_percent)",
+          "legendFormat": "error"
+        }
+      ],
+      "yaxes": [
+        {"format": "percent"},
+        {"format": "percent"}
+      ]
+    }
+  ]
+}

--- a/docs/grafana/generation-mix.json
+++ b/docs/grafana/generation-mix.json
@@ -1,0 +1,17 @@
+{
+  "title": "Generation Mix",
+  "schemaVersion": 16,
+  "version": 0,
+  "panels": [
+    {
+      "type": "piechart",
+      "title": "Generation by Source",
+      "targets": [
+        {
+          "expr": "sum by(source)(rate(power_generation_megawatts[5m]))",
+          "legendFormat": "{{source}}"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/alerts/alertmanager.yml
+++ b/monitoring/alerts/alertmanager.yml
@@ -1,0 +1,15 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ['alertname']
+  receiver: slack
+
+receivers:
+  - name: slack
+    slack_configs:
+      - api_url: ${SLACK_WEBHOOK_URL}
+        channel: '#grid-alerts'
+        send_resolved: true
+        title: '{{ template "slack.title" . }}'
+        text: '{{ template "slack.text" . }}'

--- a/monitoring/alerts/rules.yml
+++ b/monitoring/alerts/rules.yml
@@ -1,0 +1,19 @@
+groups:
+  - name: generation
+    rules:
+      - alert: HighCoalPercentage
+        expr: (sum(rate(power_generation_megawatts{source="coal"}[5m])) / sum(rate(power_generation_megawatts[5m]))) * 100 > 60
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Coal generation exceeds 60% of total generation'
+  - name: pipeline
+    rules:
+      - alert: PipelineFailure
+        expr: pipeline_status == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Data pipeline failure detected'

--- a/monitoring/exporters/airflow-prometheus.cfg
+++ b/monitoring/exporters/airflow-prometheus.cfg
@@ -1,0 +1,4 @@
+[metrics]
+# Expose Prometheus metrics via the built-in plugin
+metrics_provider = prometheus
+prometheus_port = 9102

--- a/monitoring/exporters/flink-prometheus.yaml
+++ b/monitoring/exporters/flink-prometheus.yaml
@@ -1,0 +1,3 @@
+metrics.reporters: prom
+metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+metrics.reporter.prom.port: "9250"

--- a/monitoring/exporters/kafka-prometheus.yaml
+++ b/monitoring/exporters/kafka-prometheus.yaml
@@ -1,0 +1,8 @@
+startDelaySeconds: 0
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+rules:
+  - pattern: 'kafka.server<type=(.+), name=(.+)><>Value'
+    name: kafka_$1_$2
+    type: GAUGE
+    help: 'Kafka metric $1 $2'

--- a/monitoring/exporters/spark-prometheus.yaml
+++ b/monitoring/exporters/spark-prometheus.yaml
@@ -1,0 +1,7 @@
+startDelaySeconds: 0
+jmxUrl: service:jmx:rmi:///jndi/rmi://spark-master:7077/jmxrmi
+ssl: false
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+rules:
+  - pattern: ".*"


### PR DESCRIPTION
## Summary
- add Prometheus exporter configs for Spark, Kafka, Airflow, and Flink containers
- include Grafana dashboards for generation mix, consumer lag, and forecast error
- configure Alertmanager with Slack notifications for high coal generation and pipeline failures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e55c7da64832984b26d57feb42a65