### PR TITLE
Initialize dbt project and add core models

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -1,0 +1,17 @@
+name: energy_grid
+version: 1.0.0
+config-version: 2
+
+profile: energy_grid
+
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+
+# Ensure compiled artifacts are stored inside the project
+target-path: "target"
+clean-targets: ["target", "dbt_packages"]
+
+models:
+  energy_grid:
+    +materialized: view

--- a/dbt/models/dim_region.sql
+++ b/dbt/models/dim_region.sql
@@ -1,0 +1,14 @@
+{{ config(
+    materialized='incremental',
+    partition_by={'field': 'trading_date'},
+    unique_key='region_id'
+) }}
+
+select
+    region_id,
+    trading_date,
+    region_name
+from raw_dim_region
+{% if is_incremental() %}
+  where trading_date >= (select coalesce(max(trading_date), '1900-01-01') from {{ this }})
+{% endif %}

--- a/dbt/models/dim_unit.sql
+++ b/dbt/models/dim_unit.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized='incremental',
+    partition_by={'field': 'trading_date'},
+    unique_key='unit_id'
+) }}
+
+select
+    unit_id,
+    trading_date,
+    unit_name,
+    region_id
+from raw_dim_unit
+{% if is_incremental() %}
+  where trading_date >= (select coalesce(max(trading_date), '1900-01-01') from {{ this }})
+{% endif %}

--- a/dbt/models/fact_dispatch.sql
+++ b/dbt/models/fact_dispatch.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized='incremental',
+    partition_by={'field': 'trading_date'},
+    unique_key=['trading_date', 'dispatch_interval', 'unit_id']
+) }}
+
+select
+    trading_date,
+    dispatch_interval,
+    unit_id,
+    generated_mw
+from raw_fact_dispatch
+{% if is_incremental() %}
+  where trading_date >= (select coalesce(max(trading_date), '1900-01-01') from {{ this }})
+{% endif %}

--- a/dbt/packages.yml
+++ b/dbt/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.3.0

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,0 +1,17 @@
+energy_grid:
+  target: local
+  outputs:
+    local:
+      type: sqlite
+      threads: 1
+      database: energy_grid
+      schema: main
+      schema_directory: .
+      schemas_and_paths:
+        main: energy_grid.db
+    aws:
+      type: athena
+      s3_staging_dir: s3://my-athena-bucket/staging/
+      region_name: ap-southeast-2
+      work_group: primary
+      database: lakehouse

--- a/dbt/tests/schema.yml
+++ b/dbt/tests/schema.yml
@@ -1,0 +1,25 @@
+version: 2
+
+models:
+  - name: fact_dispatch
+    columns:
+      - name: trading_date
+        tests:
+          - not_null
+      - name: generated_mw
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+  - name: dim_unit
+    columns:
+      - name: unit_id
+        tests:
+          - not_null
+          - unique
+  - name: dim_region
+    columns:
+      - name: region_id
+        tests:
+          - not_null
+          - unique


### PR DESCRIPTION
## Summary
- scaffold dbt project with packages and dual profiles for sqlite and AWS
- implement incremental models for dispatch facts and unit/region dimensions
- add schema tests for primary keys and generation ranges

## Testing
- `dbt parse --profiles-dir .`
- `dbt test --profiles-dir .` *(fails: no such table: main.dim_region)*

------
https://chatgpt.com/codex/tasks/task_e_688e55c321f88329b109cc1b1f9f0967