### PR TITLE
Add deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,97 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  AWS_REGION: ap-southeast-2
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+      - name: Run flake8
+        run: flake8 .
+      - name: Run pytest
+        run: pytest
+
+  dbt:
+    runs-on: ubuntu-latest
+    needs: lint-test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dbt
+        run: |
+          python -m pip install --upgrade pip
+          pip install dbt-core
+      - name: dbt build
+        working-directory: dbt
+        env:
+          DBT_PROFILES_DIR: ${{ github.workspace }}/dbt
+        run: |
+          dbt deps
+          dbt build
+
+  terraform:
+    runs-on: ubuntu-latest
+    needs: dbt
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - name: Terraform fmt
+        working-directory: terraform
+        run: terraform fmt -check
+      - name: Terraform init
+        working-directory: terraform
+        run: terraform init
+      - name: Terraform plan
+        if: github.event_name == 'pull_request'
+        working-directory: terraform
+        run: terraform plan -var-file=dev.tfvars
+      - name: Terraform apply
+        if: github.event_name == 'push'
+        working-directory: terraform
+        run: |
+          terraform plan -out=tfplan -var-file=prod.tfvars
+          terraform apply -auto-approve tfplan
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: dbt
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/amazon-ecr-login@v2
+        id: login-ecr
+      - name: Build and push image
+        run: |
+          docker build -t ${{ steps.login-ecr.outputs.registry }}/flink-job:latest flink_jobs
+          docker push ${{ steps.login-ecr.outputs.registry }}/flink-job:latest
+
+  airflow-sync:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - uses: actions/checkout@v4
+      - name: Sync DAGs to MWAA
+        env:
+          MWAA_BUCKET: ${{ secrets.MWAA_BUCKET }}
+        run: |
+          aws s3 sync airflow/dags s3://$MWAA_BUCKET/dags


### PR DESCRIPTION
## Summary
- add deploy workflow to lint/test code, build dbt models, run terraform, build Docker images, and sync Airflow DAGs
- reference AWS, Grafana, and Slack secrets for CI jobs

## Testing
- `flake8 .` *(fails: line too long etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyspark')*

