### PR TITLE
Add Great Expectations suites for dispatch validation

### DIFF
--- a/great_expectations/expectations/bronze_suite.yml
+++ b/great_expectations/expectations/bronze_suite.yml
@@ -2,14 +2,34 @@ expectation_suite_name: bronze_suite
 expectations:
   - expectation_type: expect_column_values_to_not_be_null
     kwargs:
-      column: id
+      column: trading_interval
   - expectation_type: expect_column_values_to_not_be_null
     kwargs:
-      column: reading
+      column: unit_id
+  - expectation_type: expect_column_values_to_not_be_null
+    kwargs:
+      column: generated_mw
   - expectation_type: expect_column_values_to_be_between
     kwargs:
-      column: reading
+      column: generated_mw
       min_value: 0
-      max_value: 1000
+      max_value: 10000
     meta:
-      notes: Ensure readings fall within realistic bounds
+      notes: Ensure generated_mw falls within realistic bounds
+  - expectation_type: expect_column_values_to_not_be_null
+    kwargs:
+      column: fuel_type
+  - expectation_type: expect_column_values_to_be_in_set
+    kwargs:
+      column: fuel_type
+      value_set:
+        - Coal
+        - Gas
+        - Hydro
+        - Wind
+        - Solar
+  - expectation_type: expect_compound_columns_to_be_unique
+    kwargs:
+      column_list:
+        - trading_interval
+        - unit_id

--- a/great_expectations/expectations/silver_suite.yml
+++ b/great_expectations/expectations/silver_suite.yml
@@ -2,12 +2,36 @@ expectation_suite_name: silver_suite
 expectations:
   - expectation_type: expect_column_values_to_not_be_null
     kwargs:
-      column: id
+      column: trading_interval
       mostly: 0.99
   - expectation_type: expect_column_values_to_not_be_null
     kwargs:
-      column: reading
-      mostly: 0.98
-  - expectation_type: expect_column_values_to_be_unique
+      column: unit_id
+      mostly: 0.99
+  - expectation_type: expect_column_values_to_not_be_null
     kwargs:
-      column: id
+      column: generated_mw
+      mostly: 0.98
+  - expectation_type: expect_column_values_to_be_between
+    kwargs:
+      column: generated_mw
+      min_value: 0
+      max_value: 10000
+  - expectation_type: expect_column_values_to_not_be_null
+    kwargs:
+      column: fuel_type
+      mostly: 0.95
+  - expectation_type: expect_column_values_to_be_in_set
+    kwargs:
+      column: fuel_type
+      value_set:
+        - Coal
+        - Gas
+        - Hydro
+        - Wind
+        - Solar
+  - expectation_type: expect_compound_columns_to_be_unique
+    kwargs:
+      column_list:
+        - trading_interval
+        - unit_id

--- a/jobs/data_quality.py
+++ b/jobs/data_quality.py
@@ -1,40 +1,38 @@
 """Spark jobs with integrated Great Expectations validation."""
 
+from pathlib import Path
+import yaml
+
 from pyspark.sql import SparkSession
 from great_expectations.dataset import SparkDFDataset
 
 
-def bronze_job(input_path: str) -> None:
-    """Load raw data, validate basic quality, and continue processing.
+def _validate(df, suite_name: str) -> None:
+    """Run Great Expectations validation using a YAML expectation suite."""
 
-    The expectation suite checks for null IDs, null readings, and ensures
-    readings fall within 0-1000.
-    """
+    suite_path = Path("great_expectations/expectations") / f"{suite_name}.yml"
+    with suite_path.open() as f:
+        suite = yaml.safe_load(f)
+
+    ge_df = SparkDFDataset(df)
+    validation = ge_df.validate(expectation_suite=suite)
+    if not validation["success"]:
+        raise ValueError(f"{suite_name} validation failed")
+
+
+def bronze_job(input_path: str) -> None:
+    """Load raw dispatch data and enforce basic quality rules."""
+
     spark = SparkSession.builder.appName("bronze_job").getOrCreate()
     df = spark.read.parquet(input_path)
-    ge_df = SparkDFDataset(df)
-    ge_df.expect_column_values_to_not_be_null("id")
-    ge_df.expect_column_values_to_not_be_null("reading")
-    ge_df.expect_column_values_to_be_between("reading", min_value=0, max_value=1000)
-    validation = ge_df.validate()
-    if not validation["success"]:
-        raise ValueError("Bronze validation failed")
+    _validate(df, "bronze_suite")
     # Continue with further Bronze processing here
 
 
 def silver_job(input_path: str) -> None:
-    """Validate curated data for completeness and uniqueness before loading.
+    """Validate curated dispatch data before loading to Silver layer."""
 
-    Completeness requires 99% non-null IDs and 98% non-null readings. IDs must be
-    unique.
-    """
     spark = SparkSession.builder.appName("silver_job").getOrCreate()
     df = spark.read.parquet(input_path)
-    ge_df = SparkDFDataset(df)
-    ge_df.expect_column_values_to_not_be_null("id", mostly=0.99)
-    ge_df.expect_column_values_to_not_be_null("reading", mostly=0.98)
-    ge_df.expect_column_values_to_be_unique("id")
-    validation = ge_df.validate()
-    if not validation["success"]:
-        raise ValueError("Silver validation failed")
+    _validate(df, "silver_suite")
     # Continue with further Silver processing here


### PR DESCRIPTION
## Summary
- add expectation suites for trading_interval, unit_id, generated_mw and fuel_type
- validate Bronze and Silver dispatch data against the suites in Spark jobs

## Testing
- `pytest`
