### PR TITLE
feat: add prometheus config and exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,20 @@ Secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `GRAFANA_API_KEY`, Slack 
 
 Grafana dashboards exported as JSON to `docs/grafana/` (Import ID 12050).
 
+### Viewing Grafana Dashboards
+
+1. Start the monitoring stack:
+
+   ```bash
+   docker compose up -d \
+     prometheus grafana alertmanager \
+     spark-exporter kafka-exporter flink-exporter airflow-exporter
+   ```
+
+2. Visit [http://localhost:3000](http://localhost:3000) and log in with the default `admin`/`admin` credentials.
+3. The built-in Prometheus data source is preconfigured to scrape the exporters defined in `monitoring/prometheus.yml`.
+4. Open a dashboard to explore Spark, Kafka, Flink and Airflow metrics.
+
 ---
 
 ## Cost Management

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,10 +59,59 @@ services:
     volumes:
       - ./airflow/dags:/opt/airflow/dags
 
+  spark-exporter:
+    image: prom/jmx-exporter:latest
+    command:
+      - "5556"
+      - "/config/spark-prometheus.yaml"
+    volumes:
+      - ./monitoring/exporters/spark-prometheus.yaml:/config/spark-prometheus.yaml
+
+  kafka-exporter:
+    image: prom/jmx-exporter:latest
+    command:
+      - "5556"
+      - "/config/kafka-prometheus.yaml"
+    volumes:
+      - ./monitoring/exporters/kafka-prometheus.yaml:/config/kafka-prometheus.yaml
+
+  flink-exporter:
+    image: prom/jmx-exporter:latest
+    command:
+      - "5556"
+      - "/config/flink-prometheus.yaml"
+    volumes:
+      - ./monitoring/exporters/flink-prometheus.yaml:/config/flink-prometheus.yaml
+
+  airflow-exporter:
+    image: prom/jmx-exporter:latest
+    command:
+      - "9102"
+      - "/config/airflow-prometheus.cfg"
+    volumes:
+      - ./monitoring/exporters/airflow-prometheus.cfg:/config/airflow-prometheus.cfg
+
+  alertmanager:
+    image: prom/alertmanager:latest
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./monitoring/alerts/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+      - ./monitoring/alerts/rules.yml:/etc/alertmanager/rules.yml
+
   prometheus:
     image: prom/prometheus:latest
+    depends_on:
+      - spark-exporter
+      - kafka-exporter
+      - flink-exporter
+      - airflow-exporter
+      - alertmanager
     ports:
       - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./monitoring/alerts/rules.yml:/etc/prometheus/rules.yml
 
   grafana:
     image: grafana/grafana:latest

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,25 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/rules.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
+scrape_configs:
+  - job_name: 'spark'
+    static_configs:
+      - targets: ['spark-exporter:5556']
+  - job_name: 'kafka'
+    static_configs:
+      - targets: ['kafka-exporter:5556']
+  - job_name: 'flink'
+    static_configs:
+      - targets: ['flink-exporter:5556']
+  - job_name: 'airflow'
+    static_configs:
+      - targets: ['airflow-exporter:9102']


### PR DESCRIPTION
## Summary
- configure Prometheus to scrape Spark, Kafka, Flink and Airflow exporters
- wire JMX exporters and Alertmanager into docker-compose stack
- document how to view Grafana dashboards

## Testing
- `pytest`
