### PR TITLE
Standardize schema across pipeline

### DIFF
--- a/dbt/models/fact_dispatch.sql
+++ b/dbt/models/fact_dispatch.sql
@@ -1,15 +1,15 @@
 {{ config(
     materialized='incremental',
-    partition_by={'field': 'trading_date'},
-    unique_key=['trading_date', 'dispatch_interval', 'unit_id']
+    partition_by={'field': 'trading_interval'},
+    unique_key=['trading_interval', 'unit_id']
 ) }}
 
 select
-    trading_date,
-    dispatch_interval,
+    trading_interval,
     unit_id,
-    generated_mw
+    generated_mw,
+    fuel_type
 from raw_fact_dispatch
 {% if is_incremental() %}
-  where trading_date >= (select coalesce(max(trading_date), '1900-01-01') from {{ this }})
+  where trading_interval >= (select coalesce(max(trading_interval), '1900-01-01') from {{ this }})
 {% endif %}

--- a/great_expectations/expectations/bronze_suite.yml
+++ b/great_expectations/expectations/bronze_suite.yml
@@ -9,6 +9,10 @@ expectations:
   - expectation_type: expect_column_values_to_not_be_null
     kwargs:
       column: generated_mw
+  - expectation_type: expect_column_values_to_be_of_type
+    kwargs:
+      column: generated_mw
+      type_: DOUBLE
   - expectation_type: expect_column_values_to_be_between
     kwargs:
       column: generated_mw

--- a/great_expectations/expectations/silver_suite.yml
+++ b/great_expectations/expectations/silver_suite.yml
@@ -12,6 +12,10 @@ expectations:
     kwargs:
       column: generated_mw
       mostly: 0.98
+  - expectation_type: expect_column_values_to_be_of_type
+    kwargs:
+      column: generated_mw
+      type_: DOUBLE
   - expectation_type: expect_column_values_to_be_between
     kwargs:
       column: generated_mw

--- a/spark_jobs/bronze_stream.py
+++ b/spark_jobs/bronze_stream.py
@@ -35,8 +35,9 @@ def main():
         f"""
         CREATE TABLE IF NOT EXISTS {args.table_name} (
             trading_interval TIMESTAMP,
-            region STRING,
-            demand DOUBLE,
+            unit_id STRING,
+            generated_mw DOUBLE,
+            fuel_type STRING,
             trading_date DATE,
             ingested_at TIMESTAMP
         )
@@ -47,8 +48,9 @@ def main():
 
     schema = StructType([
         StructField("trading_interval", TimestampType()),
-        StructField("region", StringType()),
-        StructField("demand", DoubleType()),
+        StructField("unit_id", StringType()),
+        StructField("generated_mw", DoubleType()),
+        StructField("fuel_type", StringType()),
     ])
 
     raw_df = (

--- a/tests/spark/bronze_dispatch.csv
+++ b/tests/spark/bronze_dispatch.csv
@@ -1,4 +1,4 @@
-unit_id,transaction_datetime,trading_date
-UNIT1,2024-01-01 00:00:00,2024-01-01
-UNIT1,2024-01-01 00:00:00,2024-01-01
-UNIT2,2024-01-01 00:05:00,2024-01-01
+unit_id,trading_interval,generated_mw,fuel_type,trading_date
+UNIT1,2024-01-01 00:00:00,100,Coal,2024-01-01
+UNIT1,2024-01-01 00:00:00,100,Coal,2024-01-01
+UNIT2,2024-01-01 00:05:00,50,Solar,2024-01-01

--- a/tests/test_silver_batch.py
+++ b/tests/test_silver_batch.py
@@ -24,8 +24,15 @@ def test_transform_dispatch(spark):
 
     base_path = pathlib.Path(__file__).parent / "spark"
 
-    bronze_schema = "unit_id string, transaction_datetime timestamp, trading_date date"
-    bronze_df = spark.read.csv(str(base_path / "bronze_dispatch.csv"), header=True, schema=bronze_schema)
+    bronze_schema = (
+        "unit_id string, trading_interval timestamp, generated_mw double, "
+        "fuel_type string, trading_date date"
+    )
+    bronze_df = spark.read.csv(
+        str(base_path / "bronze_dispatch.csv"),
+        header=True,
+        schema=bronze_schema,
+    )
     bronze_df.write.mode("overwrite").saveAsTable("nem.bronze_dispatch")
 
     meta_schema = "unit_id string, fuel_type string, station_name string"
@@ -42,5 +49,7 @@ def test_transform_dispatch(spark):
     assert ("UNIT1", "Coal", "StationA") in rows
     assert ("UNIT2", "Solar", "StationB") in rows
 
-    # Ensure transaction_datetime is unique
-    assert result.select("transaction_datetime").distinct().count() == result.count()
+    # Ensure trading_interval and unit_id combinations are unique
+    assert (
+        result.select("trading_interval", "unit_id").distinct().count() == result.count()
+    )


### PR DESCRIPTION
## Summary
- Normalize producer output to trading_interval/unit_id/generated_mw/fuel_type
- Align Spark jobs, dbt model, and expectations to the standardized schema
- Refresh test fixtures and docs to reflect new field names

## Testing
- `pytest -q`
