### PR TITLE
Pin dependencies and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,13 @@ kangaroo-currents/
 ## Local Development Environment
 
 1. `git clone https://github.com/<you>/kangaroo-currents && cd kangaroo-currents`
-2. `cp .env.example .env` – set environment variables for storage and APIs (see below).
-3. `docker compose up -d` – spins Redpanda, MinIO, Airflow, Spark Master.
-4. Start producer: `python ingest/producer.py`.
-5. Trigger Airflow DAG `pipeline_nem` manually to generate Silver & Gold.
-6. Explore dashboards: Grafana on `localhost:3000` (admin/admin).
+2. `python -m venv .venv && source .venv/bin/activate`
+3. `pip install -r requirements.txt` – installs pinned Python deps (`pyspark`, `dbt-core`, `great_expectations`, `apache-flink`, `prophet`, `pytest`)
+4. `cp .env.example .env` – set environment variables for storage and APIs (see below).
+5. `docker compose up -d` – spins Redpanda, MinIO, Airflow, Spark Master.
+6. Start producer: `python ingest/producer.py`.
+7. Trigger Airflow DAG `pipeline_nem` manually to generate Silver & Gold.
+8. Explore dashboards: Grafana on `localhost:3000` (admin/admin).
 
 ### Environment Variables
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,9 @@
-aiohttp
-aiokafka
+aiohttp==3.12.15
+aiokafka==0.12.0
+pyspark==3.5.0
+dbt-core==1.10.6
+great_expectations==1.5.7
+apache-flink==1.20.0
+prophet==1.1.7
+pytest==8.4.1
+prometheus-client==0.22.1


### PR DESCRIPTION
## Summary
- Pin Python dependencies including PySpark, dbt-core, Great Expectations, Apache Flink (PyFlink), Prophet, pytest and Prometheus client for reproducible environments.
- Document virtualenv creation and dependency installation in README's local development setup.

## Testing
- `pip install -r requirements.txt` *(failed: BackendUnavailable: Cannot import 'setuptools.build_meta' when building apache-flink)*
- `pip install pyspark==3.5.0 dbt-core==1.10.6 great_expectations==1.5.7 prophet==1.1.7 pytest==8.4.1 prometheus-client==0.22.1`
- `pytest`

