### PR TITLE
Add staging models for silver tables and update references

### DIFF
--- a/dbt/models/dim_region.sql
+++ b/dbt/models/dim_region.sql
@@ -8,7 +8,7 @@ select
     region_id,
     trading_date,
     region_name
-from raw_dim_region
+from {{ ref('raw_dim_region') }}
 {% if is_incremental() %}
   where trading_date >= (select coalesce(max(trading_date), '1900-01-01') from {{ this }})
 {% endif %}

--- a/dbt/models/dim_unit.sql
+++ b/dbt/models/dim_unit.sql
@@ -9,7 +9,7 @@ select
     trading_date,
     unit_name,
     region_id
-from raw_dim_unit
+from {{ ref('raw_dim_unit') }}
 {% if is_incremental() %}
   where trading_date >= (select coalesce(max(trading_date), '1900-01-01') from {{ this }})
 {% endif %}

--- a/dbt/models/fact_dispatch.sql
+++ b/dbt/models/fact_dispatch.sql
@@ -8,8 +8,9 @@ select
     trading_interval,
     unit_id,
     generated_mw,
+    trading_date,
     fuel_type
-from raw_fact_dispatch
+from {{ ref('raw_fact_dispatch') }}
 {% if is_incremental() %}
   where trading_interval >= (select coalesce(max(trading_interval), '1900-01-01') from {{ this }})
 {% endif %}

--- a/dbt/models/raw_dim_region.sql
+++ b/dbt/models/raw_dim_region.sql
@@ -1,0 +1,7 @@
+{{ config(materialized='table') }}
+
+select
+    region_id,
+    trading_date,
+    region_name
+from nem.region_metadata

--- a/dbt/models/raw_dim_unit.sql
+++ b/dbt/models/raw_dim_unit.sql
@@ -1,0 +1,8 @@
+{{ config(materialized='table') }}
+
+select
+    unit_id,
+    trading_date,
+    unit_name,
+    region_id
+from nem.unit_metadata

--- a/dbt/models/raw_fact_dispatch.sql
+++ b/dbt/models/raw_fact_dispatch.sql
@@ -1,0 +1,9 @@
+{{ config(materialized='table') }}
+
+select
+    trading_interval,
+    unit_id,
+    generated_mw,
+    fuel_type,
+    trading_date
+from nem.silver_dispatch_clean

--- a/dbt/tests/schema.yml
+++ b/dbt/tests/schema.yml
@@ -1,6 +1,27 @@
 version: 2
 
 models:
+  - name: raw_fact_dispatch
+    columns:
+      - name: trading_interval
+        tests:
+          - not_null
+      - name: unit_id
+        tests:
+          - not_null
+          - unique
+  - name: raw_dim_unit
+    columns:
+      - name: unit_id
+        tests:
+          - not_null
+          - unique
+  - name: raw_dim_region
+    columns:
+      - name: region_id
+        tests:
+          - not_null
+          - unique
   - name: fact_dispatch
     columns:
       - name: trading_date


### PR DESCRIPTION
## Summary
- add staging models pulling from silver-layer tables
- use the staging models in fact and dimension models via `ref`
- extend schema tests for the new staging layer

## Testing
- `dbt build --profiles-dir .`

