### PR TITLE
Add metadata ingestion script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ CI runner performs identical plan/apply via GitHub Actions.
 
 ## Data Pipeline Details
 
+### Metadata Ingestion
+
+* `spark-submit ingest/load_metadata.py --unit-csv path/to/unit.csv --region-csv path/to/region.csv`
+  loads static unit and region metadata into Iceberg tables `nem.unit_metadata`
+  and `nem.region_metadata`.
+
 ### 9.1 Streaming Ingestion – Bronze
 
 * **Producer**: Async `aiohttp` fetch of latest AEMO dispatch CSV every 300 s.

--- a/airflow/dags/pipeline_nem.py
+++ b/airflow/dags/pipeline_nem.py
@@ -86,6 +86,28 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
     tags=["nem", "lakehouse"],
 )
 def pipeline_nem():
+    unit_csv = os.getenv(
+        "UNIT_METADATA_CSV", f"{REPO_ROOT}/tests/spark/unit_metadata.csv"
+    )
+    region_csv = os.getenv(
+        "REGION_METADATA_CSV", f"{REPO_ROOT}/tests/spark/region_metadata.csv"
+    )
+
+    load_metadata = BashOperator(
+        task_id="load_metadata",
+        bash_command=(
+            "spark-submit --packages "
+            "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:1.4.2 "
+            f"{REPO_ROOT}/ingest/load_metadata.py "
+            f"--unit-csv {unit_csv} --region-csv {region_csv}"
+        ),
+        env={
+            "AWS_ACCESS_KEY_ID": "{{ conn.minio_default.login }}",
+            "AWS_SECRET_ACCESS_KEY": "{{ conn.minio_default.password }}",
+            "AWS_ENDPOINT_URL": "{{ conn.minio_default.extra_dejson.endpoint_url }}",
+        },
+    )
+
     bronze_stream = BashOperator(
         task_id="bronze_stream",
         bash_command=f"bash {REPO_ROOT}/submit_bronze.sh",
@@ -151,7 +173,7 @@ def pipeline_nem():
         trigger_rule=TriggerRule.ONE_FAILED,
     )
 
-    bronze_stream >> silver_batch >> dbt_run >> dbt_test >> ge_validate_bronze >> ge_validate_silver
+    load_metadata >> bronze_stream >> silver_batch >> dbt_run >> dbt_test >> ge_validate_bronze >> ge_validate_silver
     ge_validate_silver >> [notify_success, notify_failure]
 
 

--- a/ingest/load_metadata.py
+++ b/ingest/load_metadata.py
@@ -1,0 +1,81 @@
+"""Load AEMO unit and region metadata CSVs into Iceberg tables.
+
+This script reads unit and region metadata from CSV files and writes them into
+Iceberg tables ``nem.unit_metadata`` and ``nem.region_metadata`` respectively.
+
+Run manually with::
+
+    spark-submit ingest/load_metadata.py --unit-csv path/to/unit.csv --region-csv path/to/region.csv
+
+In the default mode the tables are written using the Iceberg catalog.  For unit
+testing a ``use_iceberg=False`` flag is available which writes to Spark's
+default catalog instead.
+"""
+from __future__ import annotations
+
+import argparse
+from pyspark.sql import SparkSession
+from pyspark.sql.types import StructField, StructType, StringType
+
+
+def load_metadata(
+    spark: SparkSession, unit_csv: str, region_csv: str, use_iceberg: bool = True
+) -> None:
+    """Load unit and region metadata CSVs into catalog tables.
+
+    Parameters
+    ----------
+    spark:
+        Active :class:`~pyspark.sql.SparkSession`.
+    unit_csv:
+        Path to the unit metadata CSV file.
+    region_csv:
+        Path to the region metadata CSV file.
+    use_iceberg:
+        When ``True`` (default), the tables are written using the Iceberg
+        connector.  When ``False`` they are saved using Spark's built-in catalog
+        which is useful for unit tests.
+    """
+
+    unit_schema = StructType(
+        [
+            StructField("unit_id", StringType(), True),
+            StructField("fuel_type", StringType(), True),
+            StructField("station_name", StringType(), True),
+        ]
+    )
+    region_schema = StructType(
+        [
+            StructField("region_id", StringType(), True),
+            StructField("region_name", StringType(), True),
+        ]
+    )
+
+    unit_df = spark.read.csv(unit_csv, header=True, schema=unit_schema)
+    region_df = spark.read.csv(region_csv, header=True, schema=region_schema)
+
+    if use_iceberg:
+        unit_writer = unit_df.writeTo("nem.unit_metadata").using("iceberg")
+        region_writer = region_df.writeTo("nem.region_metadata").using("iceberg")
+        unit_writer.createOrReplace()
+        region_writer.createOrReplace()
+    else:  # pragma: no cover - not executed in production
+        unit_df.write.mode("overwrite").saveAsTable("nem.unit_metadata")
+        region_df.write.mode("overwrite").saveAsTable("nem.region_metadata")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Load AEMO metadata into Iceberg tables")
+    parser.add_argument("--unit-csv", required=True, help="Path to unit metadata CSV")
+    parser.add_argument("--region-csv", required=True, help="Path to region metadata CSV")
+    args = parser.parse_args()
+
+    spark = SparkSession.builder.appName("load_metadata").getOrCreate()
+    try:
+        load_metadata(spark, args.unit_csv, args.region_csv)
+    finally:
+        spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/spark/region_metadata.csv
+++ b/tests/spark/region_metadata.csv
@@ -1,0 +1,3 @@
+region_id,region_name
+NSW1,New South Wales
+QLD1,Queensland

--- a/tests/test_load_metadata.py
+++ b/tests/test_load_metadata.py
@@ -1,0 +1,37 @@
+import pathlib
+import sys
+
+import pytest
+from pyspark.sql import SparkSession
+
+# Ensure repo root on path so ingest modules can be imported
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from ingest.load_metadata import load_metadata
+
+
+@pytest.fixture(scope="session")
+def spark():
+    spark = SparkSession.builder.master("local[2]").appName("pytest-spark").getOrCreate()
+    yield spark
+    spark.stop()
+
+
+def test_load_metadata_tables(spark):
+    spark.sql("CREATE DATABASE IF NOT EXISTS nem")
+    base_path = pathlib.Path(__file__).parent / "spark"
+    unit_csv = str(base_path / "unit_metadata.csv")
+    region_csv = str(base_path / "region_metadata.csv")
+
+    load_metadata(spark, unit_csv, region_csv, use_iceberg=False)
+
+    unit_df = spark.table("nem.unit_metadata")
+    region_df = spark.table("nem.region_metadata")
+
+    assert unit_df.count() == 2
+    assert region_df.count() == 2
+
+    unit_rows = {(r.unit_id, r.station_name) for r in unit_df.collect()}
+    assert ("UNIT1", "StationA") in unit_rows
+
+    region_rows = {(r.region_id, r.region_name) for r in region_df.collect()}
+    assert ("NSW1", "New South Wales") in region_rows


### PR DESCRIPTION
## Summary
- add `ingest/load_metadata.py` for loading unit and region metadata CSVs into Iceberg tables
- integrate metadata ingestion into `pipeline_nem` Airflow DAG
- document and test metadata loading with sample region data

## Testing
- `pytest -q`


