### PR TITLE
Persist producer CRC checkpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ GRAFANA_API_KEY=
 
 # AWS profile
 AWS_PROFILE=default
+
+# Path to CRC checkpoint file for ingest producer
+CRC_CHECKPOINT_PATH=checkpoint.crc

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@
 | **NEM Dispatch SCADA**   | `https://aemo.com.au/...CSV` | every 5 min | \~60 k rows/hour |
 | **Unit Static Metadata** | AEMO unit registry CSV       | monthly     | 1 MB             |
 
-API key not required (public).  Producer script stores latest CRC to skip duplicates.
+API key not required (public).  Producer script stores latest CRC to skip duplicates and
+persists it to a checkpoint file defined by the `CRC_CHECKPOINT_PATH` environment
+variable.
 
 ---
 


### PR DESCRIPTION
## Summary
- persist last CRC to a checkpoint file to skip duplicates on restart
- allow checkpoint path via CRC_CHECKPOINT_PATH env var
- document new env var in README and .env.example

## Testing
- `python -m py_compile ingest/producer.py`
- `pytest tests/test_silver_batch.py::test_transform_dispatch -q` *(fails: pyspark.errors.exceptions.captured.SparkRuntimeException: [LOCATION_ALREADY_EXISTS])*

