### PR TITLE
Expose Kafka JMX port for Prometheus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     ports:
       - "9092:9092"
       - "9644:9644"
+      - "9999:9999"
+    environment:
+      - JMX_PORT=9999
 
   minio:
     image: minio/minio:latest

--- a/monitoring/exporters/kafka-prometheus.yaml
+++ b/monitoring/exporters/kafka-prometheus.yaml
@@ -1,4 +1,5 @@
 startDelaySeconds: 0
+jmxUrl: service:jmx:rmi:///jndi/rmi://redpanda:9999/jmxrmi
 lowercaseOutputName: true
 lowercaseOutputLabelNames: true
 rules:


### PR DESCRIPTION
## Summary
- add JMX URL to Kafka exporter configuration
- expose Kafka JMX port in docker-compose

## Testing
- `docker compose config` *(fails: command not found)*
- `yamllint docker-compose.yml monitoring/exporters/kafka-prometheus.yaml`

